### PR TITLE
This fixes module not found during 'build'

### DIFF
--- a/resources/css/tailwind.config.js
+++ b/resources/css/tailwind.config.js
@@ -1,4 +1,4 @@
-import preset from '../../../../vendor/filament/filament/tailwind.config.preset'
+import preset from '../../../../../vendor/filament/filament/tailwind.config.preset'
 
 export default {
     presets: [preset],


### PR DESCRIPTION
Fixes  'npm run build':

```
> build
> vite build

vite v5.4.11 building for production...
✓ 58 modules transformed.
x Build failed in 2.16s
error during build:
[vite:css] [postcss] Cannot find module '../../../../vendor/filament/filament/tailwind.config.preset'
```

**Solution**

This adds an extra _'../'_ into the path location at import preset in the tailwind.config.js file. 